### PR TITLE
Fix issue where hubspot form menu didn't load

### DIFF
--- a/src/Http/Controllers/FormConfigController.php
+++ b/src/Http/Controllers/FormConfigController.php
@@ -183,6 +183,14 @@ class FormConfigController extends CpController
      */
     private function getBlueprint(): BlueprintContract
     {
-        return Blueprint::find('statamic-hubspot::config');
+        if ($blueprint = Blueprint::find('statamic-hubspot::config')) {
+            return $blueprint;
+        }
+
+        $path = realpath(__DIR__.'/../../../resources/blueprints/config.yaml');
+
+        return Blueprint::make()->setContents(
+            \Statamic\Facades\YAML::parse(file_get_contents($path))
+        );
     }
 }


### PR DESCRIPTION
This pull request improves the robustness of the `getBlueprint` method in `FormConfigController` by ensuring a fallback blueprint is loaded if the primary one is not found. Specifically, it adds logic to load and parse a local YAML blueprint file as a fallback.

Blueprint loading improvements:

* Updated the `getBlueprint` method in `FormConfigController` to return a blueprint created from a local YAML file (`resources/blueprints/config.yaml`) if the standard blueprint (`statamic-hubspot::config`) is not found.

Fixes #2 